### PR TITLE
BME280読出データ不整合の防止

### DIFF
--- a/BME280/Python27/bme280_sample.py
+++ b/BME280/Python27/bme280_sample.py
@@ -59,9 +59,7 @@ def get_calib_param():
 			digH[i] = (-digH[i] ^ 0xFFFF) + 1  
 
 def readData():
-	data = []
-	for i in range (0xF7, 0xF7+8):
-		data.append(bus.read_byte_data(i2c_address,i))
+	data = bus.read_i2c_block_data(i2c_address, 0xF7, 8)
 	pres_raw = (data[0] << 12) | (data[1] << 4) | (data[2] >> 4)
 	temp_raw = (data[3] << 12) | (data[4] << 4) | (data[5] >> 4)
 	hum_raw  = (data[6] << 8)  |  data[7]


### PR DESCRIPTION
現在の BME280 のサンプルコードでは測定データのレジスタを1つ1つ読み出していますが、[データシート](https://www.mouser.com/datasheet/2/783/BST-BME280_DS001-11-844833.pdf)の 6. 冒頭に

> To  read  out  data  after  a  conversion,  it  is  strongly  recommended to  use  a  burst  read  and  not address  every  register  individually.  This will  prevent  a  possible  mix-up  of  bytes  belonging  to different measurements and reduce interface traffic.

とあるように、このままでは読み出しのタイミングによっては不整合なデータとなってしまう可能性があります。このため推奨に従って該当箇所をブロック読み出しに置き換え、全測定データを一度に読み出すようにしました。

このように全測定データを一度に読み出した場合データの整合性が保たれることが 6.1 節で保証されています。